### PR TITLE
feat(routemap, email): make routermap more precise

### DIFF
--- a/Configuration/Configuration.php
+++ b/Configuration/Configuration.php
@@ -43,12 +43,12 @@ class Configuration
     /**
      * @return string
      */
-    public function getDaffodilUrl()
+    public function getDaffodilUrl(): string
     {
         $configValue = (string) $this->_scopeConfig->getValue(
             self::DAFFODIL_URL,
             ScopeInterface::SCOPE_STORE
         );
-        return rtrim($configValue, '/') . '/';
+        return rtrim($configValue ?? '', '/') . '/';
     }
 }

--- a/Configuration/RouteMap/KeyCreator.php
+++ b/Configuration/RouteMap/KeyCreator.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Copyright © Graycore, LLC. All rights reserved.
+ * See LICENSE.md for details.
+ */
+
+declare(strict_types=1);
+
+namespace Graycore\Daffodil\Configuration\RouteMap;
+
+class KeyCreator
+{
+    const MAP_CONFIG_PATH = "daffodil/routes/";
+    const NOOP_ROUTE = "noop__index__index";
+
+    /**
+     * Create a configuration key for a given route.
+     */
+    public function create($route)
+    {
+        if (!$route) {
+            $route = self::NOOP_ROUTE;
+        }
+
+        // We may need to remove the trailing slash from the route to form the key path.
+        $route = rtrim($route, "/");
+
+        return self::MAP_CONFIG_PATH . str_replace('/', '__', strtolower($route));
+    }
+}

--- a/Configuration/RouteMap/KeyCreator.php
+++ b/Configuration/RouteMap/KeyCreator.php
@@ -26,6 +26,6 @@ class KeyCreator
         // We may need to remove the trailing slash from the route to form the key path.
         $route = rtrim($route, "/");
 
-        return self::MAP_CONFIG_PATH . str_replace('/', '__', strtolower($route));
+        return self::MAP_CONFIG_PATH . str_replace('/', '__', $route);
     }
 }

--- a/Router/Mapper.php
+++ b/Router/Mapper.php
@@ -5,13 +5,14 @@
  * See LICENSE.md for details.
  */
 
-declare (strict_types = 1);
+declare(strict_types=1);
 
 namespace Graycore\Daffodil\Router;
 
 use Graycore\Daffodil\Configuration\Configuration;
 use Graycore\Daffodil\Configuration\RouteMap;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Graycore\Daffodil\Router\RouteNormalizer;
 
 class Mapper
 {
@@ -29,7 +30,7 @@ class Mapper
     }
 
     /**
-     * Map, as generally as plausible, to a known mapped route in confirmation.
+     * Map, as generally as plausible, to a known mapped route in configuration.
      *
      * For example, this would map  "customer/index/index" to "some-path" if the
      * `$route` was "customer" and the resulting map for "customer" returned
@@ -37,14 +38,17 @@ class Mapper
      */
     public function mapRoute(string $url, string $route)
     {
-        /**
-         * The mapping scheme assumes a trailing slash.
-         */
-        if (substr($route, -1) !== "/") {
-            $route = $route . "/";
+        $norm = RouteNormalizer::normalize($route);
+
+        if (!$this->_routeMap->getMappedRoute($norm)) {
+            return $url;
         }
-        $regex = "/" . preg_quote($route, '/') . "(?:.*\/.*\/?)" . "/";
-        return preg_replace($regex, $this->_routeMap->getMappedRoute($route), $url);
+
+        return str_replace(
+            RouteNormalizer::getRouteStringFromPath($url),
+            $this->_routeMap->getMappedRoute($norm),
+            $url
+        );
     }
 
     public function mapDomain($url, $domain)

--- a/Router/RouteNormalizer.php
+++ b/Router/RouteNormalizer.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Copyright © Graycore, LLC. All rights reserved.
+ * See LICENSE.md for details.
+ */
+
+declare(strict_types=1);
+
+namespace Graycore\Daffodil\Router;
+
+use Laminas\Uri\UriFactory;
+
+class RouteNormalizer
+{
+    const FAKE_DOMAIN = "http://www.example.com";
+
+    /**
+     * Normalizes a route into a well-formed Magento route path.
+     * I.e. `customer` -> `customer/index/index`
+     */
+    public static function normalize(string $path): string
+    {
+        $url = self::coercePathToUri($path);
+        $url = UriFactory::factory($url);
+
+        $routeParts = explode('/', ltrim($url->getPath(), '/'), 4);
+
+        $parts = [];
+
+        //Handle nulls
+        $routeParts[0] = $routeParts[0] ?? 'index';
+        $routeParts[1] = $routeParts[1] ?? 'index';
+        $routeParts[2] = $routeParts[2] ?? 'index';
+
+
+        //Handle possibly falsy values like empty strings.
+        $parts[0] = $routeParts[0] ?: 'index';
+        $parts[1] = $routeParts[1] ?: 'index';
+        $parts[2] = $routeParts[2] ?: 'index';
+
+        return implode('/', $parts);
+    }
+
+    /**
+     * Retrieves the router-relevant portion of the uri.
+     */
+    public static function getRouteStringFromPath(string $url): string
+    {
+        $url = self::coercePathToUri($url);
+        $url = UriFactory::factory($url);
+
+        $routeParts = explode('/', ltrim($url->getPath(), '/'), 4);
+        $parts = [];
+
+        $parts[0] = $routeParts[0] ?? '';
+        $parts[1] = $routeParts[1] ?? '';
+        $parts[2] = $routeParts[2] ?? '';
+
+        return rtrim(implode('/', $parts), '/');
+    }
+
+    /**
+     * Takes a path, and coerces it to 
+     */
+    public static function coercePathToUri(string $path): string
+    {
+        return strpos($path, "http") !== 0
+            ? self::FAKE_DOMAIN . '/' . $path
+            : $path;
+    }
+}

--- a/Test/Unit/Configuration/RouteMap/KeyCreatorTest.php
+++ b/Test/Unit/Configuration/RouteMap/KeyCreatorTest.php
@@ -14,7 +14,7 @@ class KeyCreatorTest extends TestCase
             ['base case', '', 'daffodil/routes/noop__index__index'],
             ['happy path', 'customer/index/index', 'daffodil/routes/customer__index__index'],
             ['happy path', 'catalog/product/view', 'daffodil/routes/catalog__product__view'],
-
+            ['case check', 'customer/account/createPassword', 'daffodil/routes/customer__account__createPassword'],
         ];
     }
 

--- a/Test/Unit/Configuration/RouteMap/KeyCreatorTest.php
+++ b/Test/Unit/Configuration/RouteMap/KeyCreatorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Graycore\Daffodil\Test\Unit\Configuration\RouteMap;
+
+use Graycore\Daffodil\Configuration\RouteMap\KeyCreator;
+use PHPUnit\Framework\TestCase;
+
+class KeyCreatorTest extends TestCase
+{
+    public function routeDataProvider()
+    {
+        return [
+            ['null map', '', 'daffodil/routes/noop__index__index'],
+            ['base case', '', 'daffodil/routes/noop__index__index'],
+            ['happy path', 'customer/index/index', 'daffodil/routes/customer__index__index'],
+            ['happy path', 'catalog/product/view', 'daffodil/routes/catalog__product__view'],
+
+        ];
+    }
+
+    /**
+     * @dataProvider routeDataProvider
+     */
+    public function testCreatingAConfigKeyFromARoute(string $case, string $key, string $result)
+    {
+        $subject = new KeyCreator();
+        $this->assertEquals($result, $subject->create($key), $case);
+    }
+}

--- a/Test/Unit/Configuration/RouteMapTest.php
+++ b/Test/Unit/Configuration/RouteMapTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Graycore\Daffodil\Test\Unit\Configuration;
+
+use Graycore\Daffodil\Configuration\RouteMap;
+use Graycore\Daffodil\Configuration\RouteMap\KeyCreator;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class RouteMapTest extends TestCase
+{
+    public function routeMapProvider()
+    {
+        return [
+            ['null map', '', null, ''],
+            ['base case', '', '', ''],
+            ['typical case', 'customer/index/index', 'dashboard', 'dashboard'],
+        ];
+    }
+
+    /**
+     * @dataProvider routeMapProvider
+     */
+    public function testItRetrievesMappingsFromTheRouteMap(
+        string $case,
+        ?string $route,
+        ?string $map,
+        string $result
+    ) {
+        /**
+         * @var LoggerInterface|MockObject $logger
+         */
+        $logger = $this->createMock(LoggerInterface::class);
+
+        /**
+         * @var ScopeConfigInterface|MockObject $scopeConfig
+         */
+        $scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $scopeConfig->expects($this->once())->method('getValue')->willReturn($map);
+
+        $subject = new RouteMap(
+            $scopeConfig,
+            $logger,
+            new KeyCreator(),
+        );
+
+
+        $this->assertEquals(
+            $result,
+            $subject->getMappedRoute($route),
+            $case
+        );
+    }
+
+    public function testItLogsWhenTheresNoMapForARoute()
+    {
+        /**
+         * @var LoggerInterface|MockObject $logger
+         */
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('info');
+
+        /**
+         * @var ScopeConfigInterface|MockObject $scopeConfig
+         */
+        $scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $scopeConfig->expects($this->once())->method('getValue')->willReturn(null);
+
+        $subject = new RouteMap(
+            $scopeConfig,
+            $logger,
+            new KeyCreator(),
+        );
+
+        $subject->getMappedRoute('no-route');
+    }
+}

--- a/Test/Unit/Router/MapperTest.php
+++ b/Test/Unit/Router/MapperTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Graycore\Daffodil\Test\Unit\Router;
+
+use Graycore\Daffodil\Configuration\Configuration;
+use Graycore\Daffodil\Configuration\RouteMap;
+use Graycore\Daffodil\Router\Mapper;
+use PHPUnit\Framework\TestCase;
+
+class MapperTest extends TestCase
+{
+    public function routeTestProvider()
+    {
+        return [
+            [
+                //No Mapping, but matches, happy path
+                'https://www.domain.com/customer/index/index',
+                'customer/index/index', null,
+                'https://www.domain.com/customer/index/index'
+            ],
+            [
+                //No Mapping, but GetUrl is odd.
+                'https://www.domain.com/',
+                'customer/index/index', null,
+                'https://www.domain.com/'
+            ],
+            [
+                //Mapping, but GetUrl is odd.
+                'https://www.domain.com/',
+                'customer/index/index', 'test123',
+                'https://www.domain.com/'
+            ],
+            [
+                //Mapping, GetUrl works, happy path.
+                'https://www.domain.com/customer/index/index',
+                'customer', 'some-path',
+                'https://www.domain.com/some-path'
+            ],
+            [
+                //Short form #1
+                'https://www.domain.com/customer/index/index',
+                'customer', 'some-path',
+                'https://www.domain.com/some-path'
+            ],
+            [
+                'https://www.domain.com/customer',
+                'customer', 'some-path',
+                'https://www.domain.com/some-path'
+            ],
+            [
+                'https://www.domain.com/customer/account/index',
+                'customer/account', 'my-account',
+                'https://www.domain.com/my-account'
+            ],
+            [
+                'https://www.domain.com/customer/account',
+                'customer/account', 'my-account',
+                'https://www.domain.com/my-account'
+            ],
+            [
+                //Short form #1
+                'https://www.domain.com/change_password/index/index',
+                'change_password', 'auth/reset-password',
+                'https://www.domain.com/auth/reset-password'
+            ],
+            [
+                //Short form #2
+                'https://www.domain.com/customer/index/index',
+                'customer/index', 'some-path',
+                'https://www.domain.com/some-path'
+            ],
+            [
+                //Long form
+                'https://www.domain.com/customer/index/index',
+                'customer/index/index', 'some-path',
+                'https://www.domain.com/some-path'
+            ],
+            [
+                //Long form with query string
+                'https://www.domain.com/customer/account/createPassword/?token=123',
+                'customer/account/createPassword', 'auth/reset-password',
+                'https://www.domain.com/auth/reset-password/?token=123'
+            ],
+            [
+                'https://www.domain.com/customer/account/confirm/?key=test123&id=123',
+                'customer/account/confirm', 'auth/confirmation',
+                'https://www.domain.com/auth/confirmation/?key=test123&id=123'
+            ],
+            [
+                //Short form, no match.
+                'https://www.domain.com/customer/account/createPassword/?token=12345',
+                'customer/account/createPassword', 'auth/reset-password',
+                'https://www.domain.com/auth/reset-password/?token=12345'
+            ],
+            [
+                'https://www.domain.com/catalog/product/view/id/1/?token=12345',
+                'catalog/product/view', null,
+                'https://www.domain.com/catalog/product/view/id/1/?token=12345'
+            ],
+            [
+                'https://www.domain.com/catalog/product/view/id/1/?token=12345',
+                'catalog/product/view', 'category',
+                'https://www.domain.com/category/id/1/?token=12345'
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider routeTestProvider
+     */
+    public function testItMapsRoutesCorrectly(string $url, string $route, ?string $map, string $result)
+    {
+        $routeMap = $this->createMock(RouteMap::class);
+        $routeMap->method('getMappedRoute')->willReturn($map);
+
+        $subject = new Mapper(
+            $this->createMock(Configuration::class),
+            $routeMap
+        );
+
+        $this->assertEquals($result, $subject->mapRoute($url, $route));
+    }
+}

--- a/Test/Unit/Router/RouteNormalizerTest.php
+++ b/Test/Unit/Router/RouteNormalizerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Graycore\Daffodil\Test\Unit\Router;
+
+use Graycore\Daffodil\Router\RouteNormalizer;
+use PHPUnit\Framework\TestCase;
+
+class RouteNormalizerTest extends TestCase
+{
+    /**
+     * Data for the test.
+     */
+    public function routeTestProvider()
+    {
+        return [
+            ['', 'index/index/index'],
+            ['customer', 'customer/index/index'],
+            ['change_password', 'change_password/index/index'],
+            ['cms', 'cms/index/index'],
+            ['cms?test=1', 'cms/index/index'],
+            ['cms?test=1', 'cms/index/index'],
+            ['cms#test1', 'cms/index/index'],
+            ['cms?test=1#test1', 'cms/index/index'],
+            ['customer/account', 'customer/account/index'],
+            ['customer/account', 'customer/account/index'],
+            ['customer/account', 'customer/account/index'],
+            ['/customer/account', 'customer/account/index'],
+            ['customer/account?test=1', 'customer/account/index'],
+            ['customer/account?test=1', 'customer/account/index'],
+            ['customer/account#test1', 'customer/account/index'],
+            ['customer/account?test=1#test1', 'customer/account/index'],
+            ['customer/account/confirm', 'customer/account/confirm'],
+            ['catalog/product/view/id/1', 'catalog/product/view'],
+            ['catalog/product/view/id/1?test=1', 'catalog/product/view'],
+            ['catalog/product/view/id/1?test=1', 'catalog/product/view'],
+            ['catalog/product/view/id/1#test1', 'catalog/product/view'],
+            ['catalog/product/view/id/1?test=1#test1', 'catalog/product/view'],
+            ['https://www.domain.com/catalog/product/view/id/1?test=1#test1', 'catalog/product/view'],
+        ];
+    }
+
+    /**
+     * @dataProvider routeTestProvider
+     */
+    public function testItNormalizesRoutesCorrectly(string $route, string $result)
+    {
+        $this->assertEquals(RouteNormalizer::normalize($route), $result);
+    }
+
+    /**
+     * Data for the test.
+     */
+    public function routePathData()
+    {
+        return [
+            ['', ''],
+            ['customer', 'customer'],
+            ['change_password', 'change_password'],
+            ['cms', 'cms'],
+            ['cms?test=1', 'cms'],
+            ['cms?test=1', 'cms'],
+            ['cms#test1', 'cms'],
+            ['cms?test=1#test1', 'cms'],
+            ['customer/account', 'customer/account'],
+            ['customer/account', 'customer/account'],
+            ['customer/account', 'customer/account'],
+            ['/customer/account', 'customer/account'],
+            ['customer/account?test=1', 'customer/account'],
+            ['customer/account?test=1', 'customer/account'],
+            ['customer/account#test1', 'customer/account'],
+            ['customer/account?test=1#test1', 'customer/account'],
+            ['customer/account/confirm', 'customer/account/confirm'],
+            ['catalog/product/view/id/1', 'catalog/product/view'],
+            ['catalog/product/view/id/1?test=1', 'catalog/product/view'],
+            ['catalog/product/view/id/1?test=1', 'catalog/product/view'],
+            ['catalog/product/view/id/1#test1', 'catalog/product/view'],
+            ['catalog/product/view/id/1?test=1#test1', 'catalog/product/view'],
+            ['http://www.domain.com/catalog/product/view/id/1?test=1#test1', 'catalog/product/view'],
+        ];
+    }
+
+    /**
+     * @dataProvider routePathData
+     */
+    public function testItComputesTheCorrectRouteStringFromThePath(string $path, string $result)
+    {
+        return $this->assertEquals(
+            RouteNormalizer::getRouteStringFromPath($path),
+            $result
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "scripts": {
         "test": "phpunit --bootstrap vendor/autoload.php test",
         "unit-test": "vendor/bin/phpunit ./Test/Unit",
+        "test:unit": "vendor/bin/phpunit ./Test/Unit",
         "lint": "phpcs . --standard=Magento2 --ignore='vendor/*'",
         "post-install-cmd": [
             "([ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/)"

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -7,8 +7,7 @@
 				<active>0</active>
 			</configuration>
 			<routes>
-				<change_password/>
-				<account/>
+				<noop__index__index>noop</noop__index__index>
 			</routes>
 		</daffodil>
 	</default>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/magento2-daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Previously, the RouteMap could really only handle routes like `customer` or `changepassword`, it could not handle other routes like `customer/index/index`.

Fixes: N/A


## What is the new behavior?
This extends support to the `daffodil/routes/*` keys to allow more complex configurations like `daffodil/routes/customer__index__index` enabling more complex route matching.

I've also added substantial test coverage to improve clarity.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

I'm fairly confident that the prior route mapping implementation didn't actually work. This corrects it and makes it more robust. 

## Other information