### PR TITLE
fix: fixing wrong redirect when restoring admin password

### DIFF
--- a/Plugins/EmulatedAdminEmailUrls.php
+++ b/Plugins/EmulatedAdminEmailUrls.php
@@ -37,6 +37,9 @@ class EmulatedAdminEmailUrls
     {
         if ($this->_configuration->isActive()) {
             $this->originalScope = $this->_urlModel->getScope();
+            if ($this->originalScope === null) {
+                $this->originalScope = $this->_store->getStore('admin');
+            }
             $this->_urlModel->setScope($this->_store->getStore());
         }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/graycoreio/magento2-daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: When resetting an admin password Magento redirects to the frontend url (in case frontend and admin urls are different). This is happening due to the potentially empty scope object in the UrlModel.


## What is the new behavior?

When the scope object is empty we use admin store, since this plugin is only applied in the admin area.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information